### PR TITLE
Refactor owner checks into reusable helper

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -6,35 +6,19 @@ Owner-only commands for user and server management.
 import discord
 from discord import app_commands
 from discord.ext import commands
-from typing import Optional
-import psutil
-import time
+from utils.permissions import is_owner
 
 class AdminCommands(commands.Cog):
     """Additional admin commands for comprehensive bot management."""
     
     def __init__(self, bot):
         self.bot = bot
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-        
-    async def cog_check(self, ctx):
-        """Check if user is the bot owner."""
-        return ctx.author.id == self.owner_id
     
     @app_commands.command(name="admin_give_role", description="🎭 Give role to user - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def give_role(self, interaction: discord.Interaction, user: discord.Member, role: discord.Role):
         """Give a role to a user."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             await user.add_roles(role)
             embed = discord.Embed(
@@ -59,18 +43,10 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_remove_role", description="❌ Remove role from user - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def remove_role(self, interaction: discord.Interaction, user: discord.Member, role: discord.Role):
         """Remove a role from a user."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             await user.remove_roles(role)
             embed = discord.Embed(
@@ -95,18 +71,11 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_user_info", description="ℹ️ Get detailed user information - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def user_info(self, interaction: discord.Interaction, user: discord.Member):
         """Get detailed user information."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
+
         # Get user roles
         roles = [role.mention for role in user.roles if role.name != "@everyone"]
         roles_text = ", ".join(roles) if roles else "No roles"
@@ -165,18 +134,10 @@ class AdminCommands(commands.Cog):
         await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_create_channel", description="📝 Create a new channel - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def create_channel(self, interaction: discord.Interaction, name: str, channel_type: str = "text"):
         """Create a new channel."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             if channel_type.lower() in ["text", "txt"]:
                 channel = await interaction.guild.create_text_channel(name=name)
@@ -218,18 +179,10 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_delete_channel", description="🗑️ Delete a channel - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def delete_channel(self, interaction: discord.Interaction, channel: discord.abc.GuildChannel):
         """Delete a channel."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             channel_name = channel.name
             await channel.delete()
@@ -255,18 +208,10 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_role_create", description="🔧 Create a new role - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def create_role(self, interaction: discord.Interaction, name: str, color: str = "default"):
         """Create a new role."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             # Parse color
             if color.lower() == "default":
@@ -301,18 +246,10 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_ban_user", description="🔨 Ban a user - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def ban_user(self, interaction: discord.Interaction, user: discord.Member, reason: str = "No reason provided"):
         """Ban a user from the server."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             await user.ban(reason=f"Admin ban by {interaction.user.name}: {reason}")
             embed = discord.Embed(
@@ -337,18 +274,10 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_unban_user", description="🔓 Unban a user - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def unban_user(self, interaction: discord.Interaction, user_id: str):
         """Unban a user from the server."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             user_id = int(user_id)
             user = await self.bot.fetch_user(user_id)
@@ -382,18 +311,10 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_kick_user", description="👢 Kick a user - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def kick_user(self, interaction: discord.Interaction, user: discord.Member, reason: str = "No reason provided"):
         """Kick a user from the server."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
         try:
             await user.kick(reason=f"Admin kick by {interaction.user.name}: {reason}")
             embed = discord.Embed(

--- a/cogs/admin_panel.py
+++ b/cogs/admin_panel.py
@@ -6,36 +6,20 @@ Owner-only commands for comprehensive bot management.
 import discord
 from discord import app_commands
 from discord.ext import commands
-from typing import Optional
-import json
-from pathlib import Path
+from utils.permissions import is_owner
 
 class AdminPanel(commands.Cog):
     """Admin panel with owner-only commands for bot management."""
     
     def __init__(self, bot):
         self.bot = bot
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-        
-    async def cog_check(self, ctx):
-        """Check if user is the bot owner."""
-        return ctx.author.id == self.owner_id
     
     @app_commands.command(name="admin", description="🔧 Admin Panel - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def admin_panel(self, interaction: discord.Interaction):
         """Open the admin panel with various management options."""
-        # Check if user is owner
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red()
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-        
+
         embed = discord.Embed(
             title="🔧 Admin Panel",
             description="Welcome to the bot administration panel. Select an option below:",
@@ -87,16 +71,14 @@ class AdminPanel(commands.Cog):
 
 class AdminPanelView(discord.ui.View):
     """View for admin panel buttons."""
-    
+
     def __init__(self, bot):
         super().__init__(timeout=300)  # 5 minute timeout
         self.bot = bot
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-    
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
         """Check if user is owner."""
-        return interaction.user.id == self.owner_id
+        return is_owner(interaction)
     
     @discord.ui.button(label="🔗 Create Webhook", style=discord.ButtonStyle.primary, row=0)
     async def create_webhook(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -321,16 +303,14 @@ class AdminPanelView(discord.ui.View):
 
 class ConfirmLeaveView(discord.ui.View):
     """Confirmation view for leaving server."""
-    
+
     def __init__(self, bot, guild):
         super().__init__(timeout=60)
         self.bot = bot
         self.guild = guild
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-    
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        return interaction.user.id == self.owner_id
+        return is_owner(interaction)
     
     @discord.ui.button(label="✅ Confirm Leave", style=discord.ButtonStyle.danger)
     async def confirm_leave(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -360,15 +340,13 @@ class ConfirmLeaveView(discord.ui.View):
 
 class UserManagementView(discord.ui.View):
     """View for user management options."""
-    
+
     def __init__(self, bot):
         super().__init__(timeout=300)
         self.bot = bot
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-    
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        return interaction.user.id == self.owner_id
+        return is_owner(interaction)
     
     @discord.ui.button(label="🎭 Give Role", style=discord.ButtonStyle.primary)
     async def give_role(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -402,15 +380,13 @@ class UserManagementView(discord.ui.View):
 
 class ServerManagementView(discord.ui.View):
     """View for server management options."""
-    
+
     def __init__(self, bot):
         super().__init__(timeout=300)
         self.bot = bot
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-    
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        return interaction.user.id == self.owner_id
+        return is_owner(interaction)
     
     @discord.ui.button(label="📝 Create Channel", style=discord.ButtonStyle.primary)
     async def create_channel(self, interaction: discord.Interaction, button: discord.ui.Button):
@@ -444,15 +420,13 @@ class ServerManagementView(discord.ui.View):
 
 class MonitoringView(discord.ui.View):
     """View for monitoring options."""
-    
+
     def __init__(self, bot):
         super().__init__(timeout=300)
         self.bot = bot
-        # Hardcoded owner ID
-        self.owner_id = 1051142172130422884
-    
+
     async def interaction_check(self, interaction: discord.Interaction) -> bool:
-        return interaction.user.id == self.owner_id
+        return is_owner(interaction)
     
     @discord.ui.button(label="📊 Performance", style=discord.ButtonStyle.primary)
     async def performance(self, interaction: discord.Interaction, button: discord.ui.Button):

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -1,0 +1,6 @@
+import discord
+
+
+def is_owner(interaction: discord.Interaction) -> bool:
+    """Check whether the interaction user is the bot owner."""
+    return interaction.user.id == 1051142172130422884


### PR DESCRIPTION
## Summary
- add `is_owner` helper in `utils.permissions`
- use `@app_commands.check(is_owner)` for admin panel and commands
- remove redundant per-command owner ID checks

## Testing
- `pytest -q` *(fails: fixture 'translations' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a239cadc088331b31c387cc1f42655