### PR TITLE
Add admin nickname command and panel button

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -94,6 +94,52 @@ class AdminCommands(commands.Cog):
             )
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
+    @app_commands.command(name="admin_change_nickname", description="✏️ Change a user's nickname - Owner Only")
+    @app_commands.default_permissions(administrator=True)
+    async def change_nickname(
+        self,
+        interaction: discord.Interaction,
+        member: discord.Member,
+        nickname: Optional[str] = None,
+    ):
+        """Change or clear a member's nickname."""
+        if interaction.user.id != self.owner_id:
+            embed = discord.Embed(
+                title="❌ Access Denied",
+                description="This command is restricted to the bot owner only.",
+                color=discord.Color.red(),
+            )
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+            return
+
+        try:
+            await member.edit(nick=nickname)
+            description = (
+                f"Successfully changed {member.mention}'s nickname to **{nickname}**"
+                if nickname
+                else f"Cleared {member.mention}'s nickname"
+            )
+            embed = discord.Embed(
+                title="✅ Nickname Updated",
+                description=description,
+                color=discord.Color.green(),
+            )
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+        except discord.Forbidden:
+            embed = discord.Embed(
+                title="❌ Permission Error",
+                description="I don't have permission to change this nickname.",
+                color=discord.Color.red(),
+            )
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+        except Exception as e:
+            embed = discord.Embed(
+                title="❌ Error",
+                description=f"Failed to change nickname: {str(e)}",
+                color=discord.Color.red(),
+            )
+            await interaction.response.send_message(embed=embed, ephemeral=True)
+
     @app_commands.command(name="admin_user_info", description="ℹ️ Get detailed user information - Owner Only")
     @app_commands.default_permissions(administrator=True)
     async def user_info(self, interaction: discord.Interaction, user: discord.Member):

--- a/cogs/admin_panel.py
+++ b/cogs/admin_panel.py
@@ -56,6 +56,7 @@ class AdminPanel(commands.Cog):
             value="• **Give Role** - Give yourself or others roles\n"
                   "• **Remove Role** - Remove roles from users\n"
                   "• **User Info** - Get detailed user information\n"
+                  "• **Change Nickname** - Change or reset user nicknames\n"
                   "• **Ban User** - Ban users from server\n"
                   "• **Unban User** - Unban users from server",
             inline=False
@@ -264,6 +265,7 @@ class AdminPanelView(discord.ui.View):
             value="• **Give Role** - Assign roles to users\n"
                   "• **Remove Role** - Remove roles from users\n"
                   "• **User Info** - Get detailed user information\n"
+                  "• **Change Nickname** - Change or reset user nicknames\n"
                   "• **Ban User** - Ban users from server\n"
                   "• **Unban User** - Unban users from server\n"
                   "• **Kick User** - Kick users from server",
@@ -396,6 +398,16 @@ class UserManagementView(discord.ui.View):
         embed = discord.Embed(
             title="ℹ️ User Info",
             description="Use `/admin_user_info @user` to get detailed user information.",
+            color=discord.Color.blue()
+        )
+        await interaction.response.edit_message(embed=embed, view=None)
+
+    @discord.ui.button(label="✏️ Change Nickname", style=discord.ButtonStyle.secondary)
+    async def change_nickname(self, interaction: discord.Interaction, button: discord.ui.Button):
+        """Show command to change a user's nickname."""
+        embed = discord.Embed(
+            title="✏️ Change Nickname",
+            description="Use `/admin_change_nickname @user new_nick` to change or clear a user's nickname.",
             color=discord.Color.blue()
         )
         await interaction.response.edit_message(embed=embed, view=None)


### PR DESCRIPTION
## Summary
- add `/admin_change_nickname` command to let the owner update or clear a member's nickname
- expose nickname change in the admin panel and user-management controls

## Testing
- `pytest` *(fails: test_translation_system.py::test_language_support, test_translation_system.py::test_translation_keys, test_translation_system.py::test_variable_formatting, test_translation_system.py::test_sample_translations)*

