### PR TITLE
Add nickname command to user management embed

### DIFF
--- a/cogs/admin_panel.py
+++ b/cogs/admin_panel.py
@@ -57,7 +57,8 @@ class AdminPanel(commands.Cog):
                   "• **Remove Role** - Remove roles from users\n"
                   "• **User Info** - Get detailed user information\n"
                   "• **Ban User** - Ban users from server\n"
-                  "• **Unban User** - Unban users from server",
+                  "• **Unban User** - Unban users from server\n"
+                  "• **Change Nickname** – Update member display names",
             inline=False
         )
         


### PR DESCRIPTION
## Summary
- expand Admin Panel's user management section with Change Nickname command

## Testing
- `pytest` (fails: fixture 'translations' not found, 5 passed, 4 errors)
