### PR TITLE
Fix admin nickname command import and psutil usage

### DIFF
--- a/cogs/admin_commands.py
+++ b/cogs/admin_commands.py
@@ -6,6 +6,7 @@ Owner-only commands for user and server management.
 import discord
 from discord import app_commands
 from discord.ext import commands
+from typing import Optional
 from utils.permissions import is_owner
 
 class AdminCommands(commands.Cog):
@@ -71,6 +72,7 @@ class AdminCommands(commands.Cog):
             await interaction.response.send_message(embed=embed, ephemeral=True)
     
     @app_commands.command(name="admin_change_nickname", description="✏️ Change a user's nickname - Owner Only")
+    @app_commands.check(is_owner)
     @app_commands.default_permissions(administrator=True)
     async def change_nickname(
         self,
@@ -79,15 +81,6 @@ class AdminCommands(commands.Cog):
         nickname: Optional[str] = None,
     ):
         """Change or clear a member's nickname."""
-        if interaction.user.id != self.owner_id:
-            embed = discord.Embed(
-                title="❌ Access Denied",
-                description="This command is restricted to the bot owner only.",
-                color=discord.Color.red(),
-            )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
-            return
-
         try:
             await member.edit(nick=nickname)
             description = (

--- a/cogs/admin_panel.py
+++ b/cogs/admin_panel.py
@@ -182,6 +182,7 @@ class AdminPanelView(discord.ui.View):
     async def bot_status(self, interaction: discord.Interaction, button: discord.ui.Button):
         """View bot statistics and status."""
         import psutil
+        import sys
         import time
         
         # Get bot statistics
@@ -213,10 +214,10 @@ class AdminPanelView(discord.ui.View):
         
         embed.add_field(
             name="🔧 System Info",
-            value=f"**Python**: {psutil.sys.version.split()[0]}\n"
+            value=f"**Python**: {sys.version.split()[0]}\n"
                   f"**Discord.py**: {discord.__version__}\n"
-                  f"**Platform**: {psutil.sys.platform}\n"
-                  f"**Architecture**: {psutil.sys.maxsize > 2**32 and '64-bit' or '32-bit'}",
+                  f"**Platform**: {sys.platform}\n"
+                  f"**Architecture**: {sys.maxsize > 2**32 and '64-bit' or '32-bit'}",
             inline=True
         )
         

--- a/test_translation_system.py
+++ b/test_translation_system.py
@@ -5,31 +5,23 @@ Run this script to test the translation functionality locally before deploying.
 """
 
 import json
-import os
 import sys
 from pathlib import Path
+import pytest
 
-def test_translation_file():
+
+@pytest.fixture
+def translations():
+    """Load translations from JSON file for tests."""
+    translations_file = Path("data/translations.json")
+    with translations_file.open('r', encoding='utf-8') as f:
+        return json.load(f)
+
+def test_translation_file(translations):
     """Test if the translations.json file exists and is valid JSON."""
     print("🔍 Testing translation file...")
-    
-    translations_file = Path("data/translations.json")
-    
-    if not translations_file.exists():
-        print("❌ Error: data/translations.json not found!")
-        return False
-    
-    try:
-        with open(translations_file, 'r', encoding='utf-8') as f:
-            translations = json.load(f)
-        print("✅ Translation file loaded successfully")
-        return translations
-    except json.JSONDecodeError as e:
-        print(f"❌ Error: Invalid JSON in translations.json: {e}")
-        return False
-    except Exception as e:
-        print(f"❌ Error loading translation file: {e}")
-        return False
+    assert isinstance(translations, dict)
+    print("✅ Translation file loaded successfully")
 
 def test_language_support(translations):
     """Test if all required languages are supported."""


### PR DESCRIPTION
## Summary
- add missing Optional typing import in admin commands
- use `is_owner` check for nickname command and drop undefined owner id
- use standard `sys` module for system info in admin panel
- add pytest fixture to load translation data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23c5b842c83318581fb37a54ba478